### PR TITLE
Install Firebase Functions dependencies before deploy

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -18,6 +18,9 @@ jobs:
       - name: Install Firebase CLI
         run: npm install -g firebase-tools@latest
 
+      - name: Install Firebase Functions dependencies
+        run: npm install --prefix functions
+
       - name: Check Firebase auth & project access
         run: |
           firebase --version
@@ -40,5 +43,4 @@ jobs:
             --debug
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-
 


### PR DESCRIPTION
## Summary
- installs the dependencies in the functions folder before Firebase deploy runs
- fixes the failed deploy error: Cannot find module 'firebase-functions'

## Notes
- this only changes the GitHub deploy workflow
- after this merges, the deploy should retry on main automatically