### PR TITLE
Allow Firebase to set functions cleanup policy

### DIFF
--- a/.github/workflows/firebase-hosting.yml
+++ b/.github/workflows/firebase-hosting.yml
@@ -40,7 +40,7 @@ jobs:
             --only hosting,functions,firestore:rules \
             --project first-grade-news-hub \
             --non-interactive \
+            --force \
             --debug
         env:
           FIREBASE_TOKEN: ${{ secrets.FIREBASE_TOKEN }}
-


### PR DESCRIPTION
## Summary
- adds Firebase's requested --force flag to the deploy command
- lets Firebase automatically set the Cloud Functions artifact cleanup policy
- fixes the latest deploy error after the function itself deployed successfully

## Notes
- this only changes the GitHub deploy workflow
- it does not change the website UI or app code